### PR TITLE
V3.11.1 and libbinutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Rspamd is an advanced spam filtering system that allows evaluation of messages b
 According to this spam score and the user’s settings, Rspamd recommends an action for the MTA to apply to the message, for example, to pass, reject or add a header. Rspamd is designed to process hundreds of messages per second simultaneously, and provides a number of useful features.
 
 
-**Shipped version:** 3.11.0~ynh1
+**Shipped version:** 3.11.1~ynh1
 ## Documentation and resources
 
 - Official app website: <https://rspamd.com/>

--- a/README_es.md
+++ b/README_es.md
@@ -23,7 +23,7 @@ Rspamd is an advanced spam filtering system that allows evaluation of messages b
 According to this spam score and the user’s settings, Rspamd recommends an action for the MTA to apply to the message, for example, to pass, reject or add a header. Rspamd is designed to process hundreds of messages per second simultaneously, and provides a number of useful features.
 
 
-**Versión actual:** 3.11.0~ynh1
+**Versión actual:** 3.11.1~ynh1
 ## Documentaciones y recursos
 
 - Sitio web oficial: <https://rspamd.com/>

--- a/README_eu.md
+++ b/README_eu.md
@@ -23,7 +23,7 @@ Rspamd is an advanced spam filtering system that allows evaluation of messages b
 According to this spam score and the user’s settings, Rspamd recommends an action for the MTA to apply to the message, for example, to pass, reject or add a header. Rspamd is designed to process hundreds of messages per second simultaneously, and provides a number of useful features.
 
 
-**Paketatutako bertsioa:** 3.11.0~ynh1
+**Paketatutako bertsioa:** 3.11.1~ynh1
 ## Dokumentazioa eta baliabideak
 
 - Aplikazioaren webgune ofiziala: <https://rspamd.com/>

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@ Rspamd is an advanced spam filtering system that allows evaluation of messages b
 According to this spam score and the user’s settings, Rspamd recommends an action for the MTA to apply to the message, for example, to pass, reject or add a header. Rspamd is designed to process hundreds of messages per second simultaneously, and provides a number of useful features.
 
 
-**Version incluse :** 3.11.0~ynh1
+**Version incluse :** 3.11.1~ynh1
 ## Documentations et ressources
 
 - Site officiel de l’app : <https://rspamd.com/>

--- a/README_gl.md
+++ b/README_gl.md
@@ -23,7 +23,7 @@ Rspamd is an advanced spam filtering system that allows evaluation of messages b
 According to this spam score and the user’s settings, Rspamd recommends an action for the MTA to apply to the message, for example, to pass, reject or add a header. Rspamd is designed to process hundreds of messages per second simultaneously, and provides a number of useful features.
 
 
-**Versión proporcionada:** 3.11.0~ynh1
+**Versión proporcionada:** 3.11.1~ynh1
 ## Documentación e recursos
 
 - Web oficial da app: <https://rspamd.com/>

--- a/README_id.md
+++ b/README_id.md
@@ -23,7 +23,7 @@ Rspamd is an advanced spam filtering system that allows evaluation of messages b
 According to this spam score and the user’s settings, Rspamd recommends an action for the MTA to apply to the message, for example, to pass, reject or add a header. Rspamd is designed to process hundreds of messages per second simultaneously, and provides a number of useful features.
 
 
-**Versi terkirim:** 3.11.0~ynh1
+**Versi terkirim:** 3.11.1~ynh1
 ## Dokumentasi dan sumber daya
 
 - Website aplikasi resmi: <https://rspamd.com/>

--- a/README_nl.md
+++ b/README_nl.md
@@ -23,7 +23,7 @@ Rspamd is an advanced spam filtering system that allows evaluation of messages b
 According to this spam score and the user’s settings, Rspamd recommends an action for the MTA to apply to the message, for example, to pass, reject or add a header. Rspamd is designed to process hundreds of messages per second simultaneously, and provides a number of useful features.
 
 
-**Geleverde versie:** 3.11.0~ynh1
+**Geleverde versie:** 3.11.1~ynh1
 ## Documentatie en bronnen
 
 - Officiele website van de app: <https://rspamd.com/>

--- a/README_pl.md
+++ b/README_pl.md
@@ -23,7 +23,7 @@ Rspamd is an advanced spam filtering system that allows evaluation of messages b
 According to this spam score and the user’s settings, Rspamd recommends an action for the MTA to apply to the message, for example, to pass, reject or add a header. Rspamd is designed to process hundreds of messages per second simultaneously, and provides a number of useful features.
 
 
-**Dostarczona wersja:** 3.11.0~ynh1
+**Dostarczona wersja:** 3.11.1~ynh1
 ## Dokumentacja i zasoby
 
 - Oficjalna strona aplikacji: <https://rspamd.com/>

--- a/README_ru.md
+++ b/README_ru.md
@@ -23,7 +23,7 @@ Rspamd is an advanced spam filtering system that allows evaluation of messages b
 According to this spam score and the user’s settings, Rspamd recommends an action for the MTA to apply to the message, for example, to pass, reject or add a header. Rspamd is designed to process hundreds of messages per second simultaneously, and provides a number of useful features.
 
 
-**Поставляемая версия:** 3.11.0~ynh1
+**Поставляемая версия:** 3.11.1~ynh1
 ## Документация и ресурсы
 
 - Официальный веб-сайт приложения: <https://rspamd.com/>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -23,7 +23,7 @@ Rspamd is an advanced spam filtering system that allows evaluation of messages b
 According to this spam score and the user’s settings, Rspamd recommends an action for the MTA to apply to the message, for example, to pass, reject or add a header. Rspamd is designed to process hundreds of messages per second simultaneously, and provides a number of useful features.
 
 
-**分发版本：** 3.11.0~ynh1
+**分发版本：** 3.11.1~ynh1
 ## 文档与资源
 
 - 官方应用网站： <https://rspamd.com/>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Rspamd"
 description.en = "Spam filtering system"
 description.fr = "Système pour filtrer les spams"
 
-version = "3.11.0~ynh1"
+version = "3.11.1~ynh1"
 
 maintainers = []
 
@@ -32,14 +32,14 @@ ram.runtime = "50M"
 [resources]
 
     [resources.sources.main]
-    amd64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.11.0-1~90a175b45~bookworm_amd64.deb"
-    amd64.sha256 = "07f58ad4cc6e41b035166ffe3b39fe73fc2fd85af54dafcb85f1bcc2d3d0c58e"
-    arm64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.11.0-1~90a175b45~bookworm_arm64.deb"
-    arm64.sha256 = "64b977c96f8a5cf8a2274e003b0789c67a018092799aadc09136095a1ced9a38"
+    amd64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.11.1-1~ab0b44951~bookworm_amd64.deb"
+    amd64.sha256 = "6cf97d07cf4c0fb8d4b1c4c7ee0d8877a3d446b35c20fa5bee429b12f9bb8f57"
+    arm64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.11.1-1~ab0b44951~bookworm_arm64.deb"
+    arm64.sha256 = "4b2cf62bc6f128bc8b57f9a189b87701986a3fa010ffec6fc2a271399b47fd6d"
     extract = false
     rename = "rspamd.deb"
 
     [resources.permissions]
 
     [resources.apt]
-    packages = "redis-server, libhyperscan5, postfix, libsodium23, libsqlite3-0, libssl3, libarchive13"
+    packages = "redis-server, libhyperscan5, postfix, libsodium23, libsqlite3-0, libssl3, libarchive13, libbinutils"


### PR DESCRIPTION
Update to the latest version 3.11.1 and add libbinutils package to prevent failed installation that i experienced from fresh install rspamd on a YunoHost fresh installation from v12 amd64 iso.
https://github.com/rspamd/rspamd/releases/tag/3.11.1
https://github.com/YunoHost-Apps/rspamd_ynh/issues/5