### PR TITLE
v3.14.2 Update version and resource URLs in manifest.toml

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Rspamd"
 description.en = "Spam filtering system"
 description.fr = "Système pour filtrer les spams"
 
-version = "3.14.0~ynh1"
+version = "3.14.2~ynh1"
 
 maintainers = []
 
@@ -34,10 +34,10 @@ ram.runtime = "50M"
 [resources]
 
     [resources.sources.main]
-    amd64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.14.0-1~e6391dc4f~bookworm_amd64.deb"
-    amd64.sha256 = "f6299764b6fffaec63020008abf1b484ba35fe1f8ffa18cb86368d0439b9b402"
-    arm64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.14.0-1~e6391dc4f~bookworm_arm64.deb"
-    arm64.sha256 = "f13aa1e6dd011e130e8690086f285a1b664c15baee16b15f08a268920675aee9"
+    amd64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.14.2-1~e6f401a~bookworm_amd64.deb"
+    amd64.sha256 = "1e1729775bf566089ec2bb8a0c8c187c71b5f1a5330b4a9a07ca9ff2abe2395f"
+    arm64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.14.2-1~e6f401a~bookworm_arm64.deb"
+    arm64.sha256 = "45bfadabbb052564b9abc14e5ed30a92795344aff525e86b6f7fd850ddf8d6d9"
     extract = false
     rename = "rspamd.deb"
 


### PR DESCRIPTION
Because :
- https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.14.0-1~e6391dc4f~bookworm_amd64.deb is 404
- https://forum.yunohost.org/t/rspamd-installation-apres-migration-vers-bookworm-non-fonctionnelle/41137
It could be considered to integrate https://github.com/rspamd/rspamd/releases/tag/3.14.2 into the testing branch even if not tagged "Latest" but is a patch release.

