### PR TITLE
Upgrade to v4.0.0

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Rspamd"
 description.en = "Spam filtering system"
 description.fr = "Système pour filtrer les spams"
 
-version = "3.14.2~ynh1"
+version = "4.0.0~ynh1"
 
 maintainers = []
 
@@ -35,18 +35,18 @@ ram.runtime = "50M"
 [resources]
 
     [resources.sources.trixie]
-    amd64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.14.2-1~e6f401a~trixie_amd64.deb"
-    amd64.sha256 = "000e1e4887fff31c5b01af98c6645082ebcbbb7c245af4c33c58f368f87ded07"
-    arm64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.14.2-1~e6f401a~trixie_arm64.deb"
-    arm64.sha256 = "7b9e4dd724496d18b542a9e0d76a66434aa32fa83d93b56fb83df56e6ad8fbdb"
+    amd64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_4.0.0-1~4a2ab73~trixie_amd64.deb"
+    amd64.sha256 = "4e4741bd33096a86ef564f27388dab03f53330f50936edc7958e18bb185e8923"
+    arm64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_4.0.0-1~4a2ab73~trixie_arm64.deb"
+    arm64.sha256 = "cd3bc534a07b18ce3249f211befbb9e28e23a22df29fd283d709329194357ea8"
     extract = false
     rename = "rspamd.deb"
 
     [resources.sources.bookworm]
-    amd64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.14.2-1~e6f401a~bookworm_amd64.deb"
-    amd64.sha256 = "1e1729775bf566089ec2bb8a0c8c187c71b5f1a5330b4a9a07ca9ff2abe2395f"
-    arm64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_3.14.2-1~e6f401a~bookworm_arm64.deb"
-    arm64.sha256 = "45bfadabbb052564b9abc14e5ed30a92795344aff525e86b6f7fd850ddf8d6d9"
+    amd64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_4.0.0-1~4a2ab73~bookworm_amd64.deb"
+    amd64.sha256 = "41df8e392c795635b2e0a219f434a04b69853ddd7d56d8933c90839c54c6355f"
+    arm64.url = "https://rspamd.com/apt-stable/pool/main/r/rspamd/rspamd_4.0.0-1~4a2ab73~bookworm_arm64.deb"
+    arm64.sha256 = "4a1eb8c0c3aa263f315cc6666a56dc72b3aff337eead27c54b98781db9fb3248"
     extract = false
     rename = "rspamd.deb"
     

--- a/tests.toml
+++ b/tests.toml
@@ -1,9 +1,14 @@
-#:schema https://raw.githubusercontent.com/YunoHost/apps/master/schemas/tests.v1.schema.json
-
 test_format = 1.0
 
 [default]
 
-    # ------------
-    # Tests to run
-    # ------------
+    # -------------------------------
+    # Default args to use for install
+    # -------------------------------
+
+
+    # -------------------------------
+    # Commits to test upgrade from
+    # -------------------------------
+
+test_upgrade_from.3224460b56498f0dc573c2e873aef595c911f880.name = "Upgrade from 3.14.2~ynh1"


### PR DESCRIPTION
A new release is out :
https://github.com/rspamd/rspamd/releases/tag/4.0.0
Upgrade from v3.14.2 to v4.0.0 and add a test upgrade