### PR TITLE
Make logrotate config optional in backup/restore

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Rspamd"
 description.en = "Spam filtering system"
 description.fr = "Système pour filtrer les spams"
 
-version = "4.1.1~ynh1"
+version = "4.1.1~ynh2"
 
 maintainers = []
 

--- a/scripts/backup
+++ b/scripts/backup
@@ -12,7 +12,12 @@ ynh_backup "/etc/dovecot/yunohost.d/post-ext.d/antispam.conf"
 
 ynh_backup "/etc/rspamd"
 
-ynh_backup "/etc/logrotate.d/$app"
+# logrotate is currently not configured by install/upgrade (ynh_config_add_logrotate
+# is commented out), so this file may not exist. Only back it up if present, otherwise
+# ynh_backup aborts and breaks the pre-upgrade safety backup.
+if [ -e "/etc/logrotate.d/$app" ]; then
+    ynh_backup "/etc/logrotate.d/$app"
+fi
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/restore
+++ b/scripts/restore
@@ -19,7 +19,11 @@ ynh_systemctl --service=dovecot --action="restart"
 
 ynh_restore "/etc/rspamd"
 
-ynh_restore "/etc/logrotate.d/$app"
+# Only restore the logrotate config if it is present in the backup archive
+# (see scripts/backup — it may be absent because logrotate is not configured).
+if [ -e "$YNH_CWD/etc/logrotate.d/$app" ]; then
+    ynh_restore "/etc/logrotate.d/$app"
+fi
 
 # Integrate rspamd in YunoHost service list
 yunohost service add $app --description="Spam filtering system"


### PR DESCRIPTION
## Problem

`scripts/backup` unconditionally backs up `/etc/logrotate.d/$app`, but
`ynh_config_add_logrotate` is commented out in `scripts/install` and
`scripts/upgrade`, so that file is never created. `ynh_backup` treats a missing
path as a fatal error (`ynh_exit_properly`), which aborts the **automatic
pre-upgrade safety backup** — making the app impossible to upgrade on affected
installs.

Observed error:

```
WARNING  File or folder '/etc/logrotate.d/rspamd' to be backed up does not exist
...
Error: Failed to collect files to be backed up
```

`scripts/restore` has the same latent issue: `ynh_restore "/etc/logrotate.d/$app"`
raises an exception when the file is not present in the archive.

Fixes #42

## Change

Guard both operations so the logrotate config is skipped when absent:

- **backup:** `if [ -e "/etc/logrotate.d/$app" ]; then ynh_backup ... fi`
- **restore:** `if [ -e "$YNH_CWD/etc/logrotate.d/$app" ]; then ynh_restore ... fi`
  (`$YNH_CWD` is the extracted-archive root used by `ynh_restore`).

This is the minimal fix and keeps behaviour identical once `ynh_config_add_logrotate`
is (re-)enabled. Version bumped to `4.1.1~ynh2`.

## How to test

1. Install rspamd (logrotate stays unconfigured).
2. `yunohost app upgrade rspamd` → safety backup now succeeds instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
